### PR TITLE
Select Warrant issuer with a weight on distance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea


### PR DESCRIPTION
Following: https://github.com/Cl3verics/SimpleWarrants/issues/4

- Use "TryRandomElementByWeight" instead of "TryRandomElement"
- Compute weight by faction's settlement distance to any playerSettlement
- Improve a bit settlement check for valid factions

Open to discussion